### PR TITLE
Fix README start instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ We use a **fake clutter generator script** to simulate disk usage and test logic
 
 ```bash
 npm install
-npm run start
+npm test
 ```
 To generate fake clutter for testing:
 node scripts/fakeClutterGenerator.js


### PR DESCRIPTION
## Summary
- fix README instructions to run test and clutter generator

## Testing
- `npm install`
- `npm test`
- `node scripts/fakeClutterGenerator.js`

------
https://chatgpt.com/codex/tasks/task_e_6844f1ab3b348323a232ce0141b23d40