### PR TITLE
Fix tests for older Node versions

### DIFF
--- a/tests/clutterGenerator.test.js
+++ b/tests/clutterGenerator.test.js
@@ -1,11 +1,12 @@
 const fs = require("fs");
 const path = require("path");
 const { generateFakeClutter } = require("../scripts/fakeClutterGenerator");
+const { removeDir } = require("./testUtils");
 
 const TEST_DIR = path.join(__dirname, "tmp-disk");
 
 afterAll(() => {
-  fs.rmSync(TEST_DIR, { recursive: true, force: true });
+  removeDir(TEST_DIR);
 });
 
 test("generateFakeClutter creates files", async () => {

--- a/tests/logger.test.js
+++ b/tests/logger.test.js
@@ -1,11 +1,12 @@
 const fs = require("fs");
 const path = require("path");
 const { logDeletion } = require("../logger");
+const { removeDir } = require("./testUtils");
 
 const LOG_DIR = path.join(__dirname, "logs-test");
 
 afterAll(() => {
-  fs.rmSync(LOG_DIR, { recursive: true, force: true });
+  removeDir(LOG_DIR);
 });
 
 test("logDeletion writes a log entry", async () => {

--- a/tests/testUtils.js
+++ b/tests/testUtils.js
@@ -1,0 +1,25 @@
+const fs = require("fs");
+const path = require("path");
+
+function removeDir(target) {
+  if (fs.rmSync) {
+    fs.rmSync(target, { recursive: true, force: true });
+    return;
+  }
+  if (!fs.existsSync(target)) return;
+  const stats = fs.lstatSync(target);
+  if (stats.isDirectory()) {
+    for (const item of fs.readdirSync(target)) {
+      removeDir(path.join(target, item));
+    }
+    fs.rmdirSync(target);
+  } else {
+    try {
+      fs.unlinkSync(target);
+    } catch (err) {
+      // ignore errors when force deleting
+    }
+  }
+}
+
+module.exports = { removeDir };


### PR DESCRIPTION
## Summary
- ensure test cleanup works on Node versions without `fs.rmSync`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6844f295ada083238252f5f0d178b939