### PR TITLE
Fix logger test

### DIFF
--- a/tests/logger.test.js
+++ b/tests/logger.test.js
@@ -5,6 +5,10 @@ const { removeDir } = require("./testUtils");
 
 const LOG_DIR = path.join(__dirname, "logs-test");
 
+beforeEach(() => {
+  removeDir(LOG_DIR);
+});
+
 afterAll(() => {
   removeDir(LOG_DIR);
 });


### PR DESCRIPTION
## Summary
- clean up log directory before each logger test

## Testing
- `npx jest --runInBand`


------
https://chatgpt.com/codex/tasks/task_e_6844f487a6088323b316e609d26f6b09