### PR TITLE
Add Prettier config and formatting command

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,4 @@
+{
+  "tabWidth": 2,
+  "singleQuote": true
+}

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 ## 🚀 Vision
 
 The goal of WiseDisk is to move beyond simple file size analysis and build an intelligent cleanup assistant that:
+
 - Understands the role and risk of each file/folder
 - Suggests safe deletion candidates
 - Logs every operation for transparency and rollback
@@ -30,6 +31,7 @@ The goal of WiseDisk is to move beyond simple file size analysis and build an in
 ## 📅 Milestone Roadmap
 
 ### ✅ MVP v0.1 – Basic Functionality
+
 - [x] Simulate fake disk clutter for testing
 - [x] Scan and display a tree of folders/files with sizes
 - [x] Allow checkbox-based deletion through Recycle Bin
@@ -37,11 +39,13 @@ The goal of WiseDisk is to move beyond simple file size analysis and build an in
 - [ ] Support rollback through logs or file restoration
 
 ### 🔜 v0.2 – Categorization and Scoring
+
 - [ ] Tag files/folders (system, user, temp, dev, etc.)
 - [ ] Assign deletability score
 - [ ] Filter or sort by score
 
 ### 🔮 v0.3+ – LLM and Intelligent Suggestions
+
 - [ ] Chat assistant to explain folders or suggest deletions
 - [ ] Natural language command interface
 - [ ] Custom script generator (e.g., delete all unused `.log` files > 100MB)
@@ -60,6 +64,9 @@ We use a **fake clutter generator script** to simulate disk usage and test logic
 npm install
 npm test
 npm start
+npm run format
 ```
+
+Run `npm run format` to apply Prettier formatting to the project files.
 To generate fake clutter for testing:
 node scripts/fakeClutterGenerator.js

--- a/index.js
+++ b/index.js
@@ -1,11 +1,11 @@
-const { app, BrowserWindow, ipcMain } = require("electron");
-const fs = require("fs");
-const path = require("path");
-const trash = require("trash");
-const { scanDirectory } = require("./scanner");
-const { logDeletion } = require("./logger");
+const { app, BrowserWindow, ipcMain } = require('electron');
+const fs = require('fs');
+const path = require('path');
+const trash = require('trash');
+const { scanDirectory } = require('./scanner');
+const { logDeletion } = require('./logger');
 
-const TEST_DISK = path.join(__dirname, "test-disk");
+const TEST_DISK = path.join(__dirname, 'test-disk');
 
 function createWindow() {
   const win = new BrowserWindow({
@@ -16,12 +16,12 @@ function createWindow() {
       contextIsolation: false,
     },
   });
-  win.loadFile("index.html");
+  win.loadFile('index.html');
 }
 
 app.whenReady().then(createWindow);
 
-ipcMain.handle("scan", async () => {
+ipcMain.handle('scan', async () => {
   try {
     return await scanDirectory(TEST_DISK);
   } catch (err) {
@@ -29,7 +29,7 @@ ipcMain.handle("scan", async () => {
   }
 });
 
-ipcMain.handle("delete", async (event, paths) => {
+ipcMain.handle('delete', async (event, paths) => {
   for (const filePath of paths) {
     try {
       const stats = await fs.promises.stat(filePath);
@@ -41,8 +41,8 @@ ipcMain.handle("delete", async (event, paths) => {
   }
 });
 
-app.on("window-all-closed", () => {
-  if (process.platform !== "darwin") {
+app.on('window-all-closed', () => {
+  if (process.platform !== 'darwin') {
     app.quit();
   }
 });

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,4 +1,4 @@
 module.exports = {
-  testEnvironment: "node",
-  roots: ["<rootDir>/tests"],
+  testEnvironment: 'node',
+  roots: ['<rootDir>/tests'],
 };

--- a/logger.js
+++ b/logger.js
@@ -1,11 +1,11 @@
-const fs = require("fs/promises");
-const path = require("path");
+const fs = require('fs/promises');
+const path = require('path');
 
 /**
  * Append a deletion log entry to a JSON file within the logs directory.
  * Returns the path to the log file written.
  */
-async function logDeletion(entry, logDir = path.join(__dirname, "logs")) {
+async function logDeletion(entry, logDir = path.join(__dirname, 'logs')) {
   await fs.mkdir(logDir, { recursive: true });
   const logPath = path.join(
     logDir,
@@ -13,10 +13,10 @@ async function logDeletion(entry, logDir = path.join(__dirname, "logs")) {
   );
   let data = [];
   try {
-    const fileData = await fs.readFile(logPath, "utf-8");
+    const fileData = await fs.readFile(logPath, 'utf-8');
     data = JSON.parse(fileData);
   } catch (err) {
-    if (err.code !== "ENOENT") throw err;
+    if (err.code !== 'ENOENT') throw err;
   }
   data.push({
     path: entry.path,

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "main": "index.js",
   "scripts": {
     "test": "jest",
-    "start": "electron ."
+    "start": "electron .",
+    "format": "prettier --write ."
   },
   "keywords": [],
   "author": "",

--- a/renderer.js
+++ b/renderer.js
@@ -1,14 +1,14 @@
-const { ipcRenderer } = require("electron");
+const { ipcRenderer } = require('electron');
 
 function createTree(nodes) {
-  const ul = document.createElement("ul");
+  const ul = document.createElement('ul');
   for (const node of nodes) {
-    const li = document.createElement("li");
-    const checkbox = document.createElement("input");
-    checkbox.type = "checkbox";
+    const li = document.createElement('li');
+    const checkbox = document.createElement('input');
+    checkbox.type = 'checkbox';
     checkbox.dataset.path = node.path;
     li.appendChild(checkbox);
-    const label = document.createElement("span");
+    const label = document.createElement('span');
     label.textContent = `${node.name} (${(node.size / 1024).toFixed(1)} KB)`;
     li.appendChild(label);
     if (node.isDirectory && node.children) {
@@ -19,17 +19,17 @@ function createTree(nodes) {
   return ul;
 }
 
-ipcRenderer.invoke("scan").then((data) => {
-  const container = document.getElementById("tree");
+ipcRenderer.invoke('scan').then((data) => {
+  const container = document.getElementById('tree');
   container.appendChild(createTree(data));
 });
 
-document.getElementById("delete").addEventListener("click", async () => {
+document.getElementById('delete').addEventListener('click', async () => {
   const checked = Array.from(
-    document.querySelectorAll("input[type=checkbox]"),
+    document.querySelectorAll('input[type=checkbox]'),
   ).filter((c) => c.checked);
   const paths = checked.map((c) => c.dataset.path);
   if (paths.length === 0) return;
-  await ipcRenderer.invoke("delete", paths);
+  await ipcRenderer.invoke('delete', paths);
   window.location.reload();
 });

--- a/scanner.js
+++ b/scanner.js
@@ -1,5 +1,5 @@
-const fs = require("fs/promises");
-const path = require("path");
+const fs = require('fs/promises');
+const path = require('path');
 
 async function getFolderSize(dir) {
   let total = 0;

--- a/scripts/fakeClutterGenerator.js
+++ b/scripts/fakeClutterGenerator.js
@@ -1,5 +1,5 @@
-const fs = require("fs/promises");
-const path = require("path");
+const fs = require('fs/promises');
+const path = require('path');
 
 /**
  * Generate a small amount of fake clutter in the target directory.
@@ -7,13 +7,13 @@ const path = require("path");
  */
 async function generateFakeClutter(targetDir) {
   await fs.mkdir(targetDir, { recursive: true });
-  const filePath = path.join(targetDir, "dummy.tmp");
-  await fs.writeFile(filePath, "dummy data");
+  const filePath = path.join(targetDir, 'dummy.tmp');
+  await fs.writeFile(filePath, 'dummy data');
   return [filePath];
 }
 
 if (require.main === module) {
-  generateFakeClutter(path.join(__dirname, "..", "test-disk")).catch((err) => {
+  generateFakeClutter(path.join(__dirname, '..', 'test-disk')).catch((err) => {
     console.error(err);
     process.exit(1);
   });

--- a/tests/clutterGenerator.test.js
+++ b/tests/clutterGenerator.test.js
@@ -1,15 +1,15 @@
-const fs = require("fs");
-const path = require("path");
-const { generateFakeClutter } = require("../scripts/fakeClutterGenerator");
-const { removeDir } = require("./testUtils");
+const fs = require('fs');
+const path = require('path');
+const { generateFakeClutter } = require('../scripts/fakeClutterGenerator');
+const { removeDir } = require('./testUtils');
 
-const TEST_DIR = path.join(__dirname, "tmp-disk");
+const TEST_DIR = path.join(__dirname, 'tmp-disk');
 
 afterAll(() => {
   removeDir(TEST_DIR);
 });
 
-test("generateFakeClutter creates files", async () => {
+test('generateFakeClutter creates files', async () => {
   const files = await generateFakeClutter(TEST_DIR);
   for (const file of files) {
     expect(fs.existsSync(file)).toBe(true);

--- a/tests/logger.test.js
+++ b/tests/logger.test.js
@@ -1,9 +1,9 @@
-const fs = require("fs");
-const path = require("path");
-const { logDeletion } = require("../logger");
-const { removeDir } = require("./testUtils");
+const fs = require('fs');
+const path = require('path');
+const { logDeletion } = require('../logger');
+const { removeDir } = require('./testUtils');
 
-const LOG_DIR = path.join(__dirname, "logs-test");
+const LOG_DIR = path.join(__dirname, 'logs-test');
 
 beforeEach(() => {
   removeDir(LOG_DIR);
@@ -13,14 +13,14 @@ afterAll(() => {
   removeDir(LOG_DIR);
 });
 
-test("logDeletion writes a log entry", async () => {
+test('logDeletion writes a log entry', async () => {
   const logPath = await logDeletion(
-    { path: "example.tmp", size: 123 },
+    { path: 'example.tmp', size: 123 },
     LOG_DIR,
   );
   expect(fs.existsSync(logPath)).toBe(true);
-  const content = JSON.parse(fs.readFileSync(logPath, "utf8"));
+  const content = JSON.parse(fs.readFileSync(logPath, 'utf8'));
   expect(content.length).toBe(1);
-  expect(content[0].path).toBe("example.tmp");
+  expect(content[0].path).toBe('example.tmp');
   expect(content[0].size).toBe(123);
 });

--- a/tests/testUtils.js
+++ b/tests/testUtils.js
@@ -1,5 +1,5 @@
-const fs = require("fs");
-const path = require("path");
+const fs = require('fs');
+const path = require('path');
 
 function removeDir(target) {
   if (fs.rmSync) {


### PR DESCRIPTION
## Summary
- add `.prettierrc` using 2-space indent and single quotes
- add `format` script in `package.json`
- document running `npm run format` in README
- run Prettier across repo

## Testing
- `npm run format`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6844f896fea883239595f0c7beb1a36c