### PR TITLE
Improve fake clutter generator with nested folders

### DIFF
--- a/scripts/fakeClutterGenerator.js
+++ b/scripts/fakeClutterGenerator.js
@@ -1,15 +1,58 @@
 const fs = require("fs/promises");
 const path = require("path");
 
+const MIN_SIZE = 100 * 1024; // 100 KB
+const MAX_SIZE = 2 * 1024 * 1024 * 1024; // 2 GB
+const MIN_DAYS = 30;
+const MAX_DAYS = 900;
+const EXTENSIONS = [".tmp", ".log", ".zip", ".bak", ".txt"];
+
+function randInt(min, max) {
+  return Math.floor(Math.random() * (max - min + 1)) + min;
+}
+
+function randomExt() {
+  return EXTENSIONS[randInt(0, EXTENSIONS.length - 1)];
+}
+
+function randomPastDate() {
+  const daysAgo = randInt(MIN_DAYS, MAX_DAYS);
+  return new Date(Date.now() - daysAgo * 24 * 60 * 60 * 1000);
+}
+
+async function createRandomFile(dir, index) {
+  const name = `file-${index}-${Date.now()}${randomExt()}`;
+  const filePath = path.join(dir, name);
+  await fs.writeFile(filePath, Buffer.alloc(1));
+  const size = randInt(MIN_SIZE, MAX_SIZE);
+  await fs.truncate(filePath, size);
+  const mtime = randomPastDate();
+  await fs.utimes(filePath, mtime, mtime);
+  return filePath;
+}
+
+async function populateDir(dir, depth, createdPaths) {
+  await fs.mkdir(dir, { recursive: true });
+  for (let i = 0; i < 3; i++) {
+    const p = await createRandomFile(dir, i);
+    createdPaths.push(p);
+  }
+  if (depth > 0) {
+    for (let i = 0; i < 2; i++) {
+      const sub = path.join(dir, `sub-${depth}-${i}`);
+      await populateDir(sub, depth - 1, createdPaths);
+    }
+  }
+}
+
 /**
- * Generate a small amount of fake clutter in the target directory.
+ * Generate nested fake clutter in the target directory.
  * Returns an array of created file paths.
  */
 async function generateFakeClutter(targetDir) {
-  await fs.mkdir(targetDir, { recursive: true });
-  const filePath = path.join(targetDir, "dummy.tmp");
-  await fs.writeFile(filePath, "dummy data");
-  return [filePath];
+  const created = [];
+  await populateDir(targetDir, 2, created);
+  return created;
 }
 
 if (require.main === module) {

--- a/tests/clutterGenerator.test.js
+++ b/tests/clutterGenerator.test.js
@@ -9,9 +9,23 @@ afterAll(() => {
   removeDir(TEST_DIR);
 });
 
-test("generateFakeClutter creates files", async () => {
+test("generateFakeClutter creates nested files with metadata", async () => {
   const files = await generateFakeClutter(TEST_DIR);
+  expect(files.length).toBeGreaterThan(0);
+  let hasNested = false;
   for (const file of files) {
     expect(fs.existsSync(file)).toBe(true);
+    const stats = fs.statSync(file);
+    // size between 100KB and 2GB
+    expect(stats.size).toBeGreaterThanOrEqual(100 * 1024);
+    expect(stats.size).toBeLessThanOrEqual(2 * 1024 * 1024 * 1024);
+    // modified time between 30 and 900 days ago
+    const ageDays = (Date.now() - stats.mtimeMs) / (1000 * 60 * 60 * 24);
+    expect(ageDays).toBeGreaterThanOrEqual(30);
+    expect(ageDays).toBeLessThan(901);
+    if (path.dirname(file) !== TEST_DIR) {
+      hasNested = true;
+    }
   }
+  expect(hasNested).toBe(true);
 });


### PR DESCRIPTION
## Summary
- expand fakeClutterGenerator to create nested folders and random files
- verify nested clutter creation and metadata in tests

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6844f88f8a788323abee66ef0e8b4051