### PR TITLE
Update README with test-disk instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,5 +68,13 @@ npm run format
 ```
 
 Run `npm run format` to apply Prettier formatting to the project files.
-To generate fake clutter for testing:
+
+To generate fake clutter for testing, run:
+
+```bash
 node scripts/fakeClutterGenerator.js
+```
+
+This command creates a `test-disk` folder populated with random files and
+directories. The automated tests rely on this folder when running in the
+simulated environment only.


### PR DESCRIPTION
## Summary
- clarify how `fakeClutterGenerator.js` creates the `test-disk` folder
- mention that tests use this folder only in the simulated environment

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684501f388ac8323ae14fbc0550ca30e