### PR TITLE
Add rollback script and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,14 @@ The goal of WiseDisk is to move beyond simple file size analysis and build an in
 - [x] Scan and display a tree of folders/files with sizes
 - [x] Allow checkbox-based deletion through Recycle Bin
 - [x] Log each action to a local `.log` file
-- [ ] Support rollback through logs or file restoration
+- [x] Support rollback through logs or file restoration
+      To restore deleted files using the logs, run:
+
+```bash
+node scripts/rollback.js [logDir]
+```
+
+The `logDir` defaults to `logs/`.
 
 ### 🔜 v0.2 – Categorization and Scoring
 

--- a/scripts/rollback.js
+++ b/scripts/rollback.js
@@ -1,0 +1,69 @@
+const fs = require('fs/promises');
+const path = require('path');
+const xdgTrashdir = require('xdg-trashdir');
+
+async function getTrashDir() {
+  if (process.env.TRASH_DIR) {
+    return process.env.TRASH_DIR;
+  }
+  try {
+    const dirs = await xdgTrashdir();
+    if (Array.isArray(dirs) && dirs.length > 0) {
+      return dirs[0];
+    }
+  } catch {
+    // ignore
+  }
+  const home = process.env.HOME || process.env.USERPROFILE || __dirname;
+  return path.join(home, '.Trash');
+}
+
+async function fileExists(p) {
+  try {
+    await fs.access(p);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Restore files based on deletion log entries.
+ * @param {string} logDir directory containing deletion JSON logs
+ */
+async function restoreFromLogs(logDir = path.join(__dirname, '..', 'logs')) {
+  const trashDir = await getTrashDir();
+  const trashFiles = path.join(trashDir, 'files');
+  let files;
+  try {
+    files = await fs.readdir(logDir);
+  } catch {
+    console.error(`Log directory not found: ${logDir}`);
+    return;
+  }
+  for (const file of files) {
+    if (!file.endsWith('.json')) continue;
+    const data = JSON.parse(await fs.readFile(path.join(logDir, file), 'utf8'));
+    for (const entry of data) {
+      const original = path.resolve(entry.path);
+      const trashed = path.join(trashFiles, path.basename(original));
+      if (await fileExists(trashed)) {
+        await fs.mkdir(path.dirname(original), { recursive: true });
+        await fs.rename(trashed, original);
+        console.log(`Restored ${original}`);
+      } else {
+        console.log(`Missing ${original} in trash`);
+      }
+    }
+  }
+}
+
+if (require.main === module) {
+  const dir = process.argv[2] || path.join(__dirname, '..', 'logs');
+  restoreFromLogs(dir).catch((err) => {
+    console.error(err);
+    process.exit(1);
+  });
+}
+
+module.exports = { restoreFromLogs };

--- a/tests/rollback.test.js
+++ b/tests/rollback.test.js
@@ -1,0 +1,56 @@
+const fs = require('fs');
+const path = require('path');
+const { restoreFromLogs } = require('../scripts/rollback');
+const { removeDir } = require('./testUtils');
+
+const LOG_DIR = path.join(__dirname, 'rollback-logs');
+const TRASH_DIR = path.join(__dirname, 'fake-trash');
+const ORIGINAL_DIR = path.join(__dirname, 'orig');
+
+beforeEach(() => {
+  removeDir(LOG_DIR);
+  removeDir(TRASH_DIR);
+  removeDir(ORIGINAL_DIR);
+  fs.mkdirSync(path.join(TRASH_DIR, 'files'), { recursive: true });
+  fs.mkdirSync(LOG_DIR, { recursive: true });
+  fs.mkdirSync(ORIGINAL_DIR, { recursive: true });
+});
+
+afterAll(() => {
+  removeDir(LOG_DIR);
+  removeDir(TRASH_DIR);
+  removeDir(ORIGINAL_DIR);
+});
+
+test('restoreFromLogs restores files from trash', async () => {
+  const original = path.join(ORIGINAL_DIR, 'file.txt');
+  const trashed = path.join(TRASH_DIR, 'files', 'file.txt');
+  fs.writeFileSync(trashed, 'data');
+
+  const missing = path.join(ORIGINAL_DIR, 'missing.txt');
+
+  const logData = [
+    { path: original, size: 4, deletedAt: new Date().toISOString() },
+    { path: missing, size: 0, deletedAt: new Date().toISOString() },
+  ];
+  fs.writeFileSync(
+    path.join(LOG_DIR, 'deletions.json'),
+    JSON.stringify(logData, null, 2),
+  );
+
+  process.env.TRASH_DIR = TRASH_DIR;
+  const messages = [];
+  const spy = jest.spyOn(console, 'log').mockImplementation((msg) => {
+    messages.push(msg);
+  });
+
+  await restoreFromLogs(LOG_DIR);
+
+  spy.mockRestore();
+  delete process.env.TRASH_DIR;
+
+  expect(fs.existsSync(original)).toBe(true);
+  expect(fs.existsSync(trashed)).toBe(false);
+  expect(messages.some((m) => m.includes('Restored'))).toBe(true);
+  expect(messages.some((m) => m.includes('Missing'))).toBe(true);
+});


### PR DESCRIPTION
## Summary
- implement `restoreFromLogs` for restoring files from logs
- document rollback usage in README
- add unit test for rollback

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684504e9148483239c2c0410a090b47b