### PR TITLE
Fix CommonJS trash import

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 const { app, BrowserWindow, ipcMain } = require('electron');
 const fs = require('fs');
 const path = require('path');
-const trash = require('trash');
+const { default: trash } = require('trash');
 const { scanDirectory } = require('./scanner');
 const { logDeletion } = require('./logger');
 


### PR DESCRIPTION
## Summary
- fix import of ESM-only `trash` package when running in CommonJS

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68450e2a01cc8323aae4fe9ed30f0f43