### PR TITLE
Fix data reference in renderer

### DIFF
--- a/renderer.js
+++ b/renderer.js
@@ -68,10 +68,10 @@ function createTree(nodes) {
 }
 
 document.addEventListener('DOMContentLoaded', async () => {
-  const data = await ipcRenderer.invoke('scan');
+  const treeData = await ipcRenderer.invoke('scan');
   const container = document.getElementById('file-list');
   if (container) {
-    container.appendChild(createTree(data));
+    container.appendChild(createTree(treeData));
   }
 
   document.getElementById('delete').addEventListener('click', async () => {


### PR DESCRIPTION
## Summary
- rename `data` variable in renderer to avoid global collision

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68451456ae8483238f7112931a88d250