### PR TITLE
Add collapsible folder tree

### DIFF
--- a/renderer.js
+++ b/renderer.js
@@ -47,21 +47,39 @@ function createTree(nodes) {
     });
     row.appendChild(checkbox);
 
-    const label = document.createElement('span');
-    label.classList.add('label');
-    label.textContent = `${getIcon(node.name, node.isDirectory)} ${node.name} (${formatSize(node.size)})`;
-    row.appendChild(label);
-
-    li.appendChild(row);
+    let label = null;
+    let childUl = null;
 
     if (node.isDirectory && node.children) {
-      label.classList.add('collapsible');
-      const childUl = createTree(node.children);
-      childUl.classList.add('nested');
-      label.addEventListener('click', () => {
-        childUl.classList.toggle('collapsed');
-      });
+      const toggle = document.createElement('span');
+      toggle.textContent = '▶️';
+      toggle.classList.add('toggle');
+      row.appendChild(toggle);
+
+      label = document.createElement('span');
+      label.classList.add('label', 'collapsible');
+      label.textContent = `${getIcon(node.name, node.isDirectory)} ${node.name} (${formatSize(node.size)})`;
+      row.appendChild(label);
+
+      childUl = createTree(node.children);
+      childUl.classList.add('nested', 'collapsed');
+
+      const toggleChildren = () => {
+        const collapsed = childUl.classList.toggle('collapsed');
+        toggle.textContent = collapsed ? '▶️' : '🔽';
+      };
+
+      toggle.addEventListener('click', toggleChildren);
+      label.addEventListener('click', toggleChildren);
+
+      li.appendChild(row);
       li.appendChild(childUl);
+    } else {
+      label = document.createElement('span');
+      label.classList.add('label');
+      label.textContent = `${getIcon(node.name, node.isDirectory)} ${node.name} (${formatSize(node.size)})`;
+      row.appendChild(label);
+      li.appendChild(row);
     }
 
     ul.appendChild(li);

--- a/style.css
+++ b/style.css
@@ -45,6 +45,11 @@ ul {
   display: none;
 }
 
+.toggle {
+  cursor: pointer;
+  margin-right: 6px;
+}
+
 .collapsible {
   cursor: pointer;
 }


### PR DESCRIPTION
## Summary
- make nested folders collapsed by default with an expand/collapse toggle
- hide nested lists with CSS

## Testing
- `npm run format`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68451cb7d140832385d9eca692d292bc