### PR TITLE
Add rollback UI

### DIFF
--- a/index.html
+++ b/index.html
@@ -16,6 +16,15 @@
     </header>
     <div id="file-list"></div>
     <button id="delete">Delete Selected</button>
+    <button id="restore">Restore from Deletion Log</button>
+    <dialog id="restore-dialog">
+      <h2>Select deletion log</h2>
+      <select id="log-select"></select>
+      <div>
+        <button id="confirm-restore">Restore</button>
+        <button id="cancel-restore">Cancel</button>
+      </div>
+    </dialog>
     <script src="renderer.js"></script>
   </body>
 </html>

--- a/renderer.js
+++ b/renderer.js
@@ -94,6 +94,38 @@ document.addEventListener('DOMContentLoaded', async () => {
     container.appendChild(createTree(treeData));
   }
 
+  async function showRestoreDialog() {
+    const logs = await ipcRenderer.invoke('listLogs');
+    const select = document.getElementById('log-select');
+    select.innerHTML = '';
+    for (const log of logs) {
+      const option = document.createElement('option');
+      option.value = log;
+      option.textContent = log;
+      select.appendChild(option);
+    }
+    document.getElementById('restore-dialog').showModal();
+  }
+
+  document
+    .getElementById('restore')
+    .addEventListener('click', showRestoreDialog);
+
+  document.getElementById('cancel-restore').addEventListener('click', () => {
+    document.getElementById('restore-dialog').close();
+  });
+
+  document
+    .getElementById('confirm-restore')
+    .addEventListener('click', async () => {
+      const file = document.getElementById('log-select').value;
+      document.getElementById('restore-dialog').close();
+      if (!file) return;
+      const ok = await ipcRenderer.invoke('rollback', file);
+      alert(ok ? 'Restore completed' : 'Restore failed');
+      window.location.reload();
+    });
+
   document.getElementById('delete').addEventListener('click', async () => {
     const checked = Array.from(
       document.querySelectorAll('input[type=checkbox]'),

--- a/style.css
+++ b/style.css
@@ -86,3 +86,20 @@ ul {
 #delete:hover {
   background-color: #c9302c;
 }
+
+#restore {
+  position: fixed;
+  bottom: 20px;
+  left: 20px;
+  padding: 10px 20px;
+  background-color: #5cb85c;
+  color: #fff;
+  border: none;
+  border-radius: 4px;
+  font-size: 16px;
+  cursor: pointer;
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.2);
+}
+#restore:hover {
+  background-color: #4cae4c;
+}


### PR DESCRIPTION
## Summary
- add Restore button and dialog to pick deletion logs
- wire renderer to main with IPC calls to run rollback.js
- extend rollback.js to accept log file paths

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68451de7c0fc8323be309560055c3404